### PR TITLE
adding meta-npm-outdated

### DIFF
--- a/bin/meta-npm
+++ b/bin/meta-npm
@@ -11,6 +11,7 @@ program
   .command('clean', 'delete the node_modules folder in meta and child repositories')
   .command('install', 'npm install meta and child repositories')
   .command('link [--all]', 'npm link child repositories where used within child and meta repositories')
+  .command('outdated', 'check outdated dependencies in meta and child repositories')
   .command('publish', 'npm publish meta and child repositories')
   .command('run', 'npm run commands against meta and child repositories')
   .command('symlink', 'directly symlink meta and child repositories without using global npm link')

--- a/bin/meta-npm-outdated
+++ b/bin/meta-npm-outdated
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+const debug = require('debug')('meta-npm-oudated');
+const metaLoop = require('meta-loop');
+
+if (process.argv[2] === '--help') {
+  return console.log(`\n  usage:\n\n    meta npm outdated\n`);
+}
+
+metaLoop('npm outdated');

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "meta-npm-clean": "./bin/meta-npm-clean",
     "meta-npm-install": "./bin/meta-npm-install",
     "meta-npm-link": "./bin/meta-npm-link",
+    "meta-npm-outdated": "./bin/meta-npm-oudated",
     "meta-npm-publish": "./bin/meta-npm-publish",
     "meta-npm-run": "./bin/meta-npm-run",
     "meta-npm-symlink": "./bin/meta-npm-symlink"


### PR DESCRIPTION
This PR adds `meta npm outdated` command which checks outdated dependencies in meta and projects workspaces.